### PR TITLE
Fix embedded records stored in root

### DIFF
--- a/addon/adapters/firebase.js
+++ b/addon/adapters/firebase.js
@@ -686,7 +686,7 @@ export default DS.Adapter.extend(Waitable, {
       return recordRef;
     }
 
-    return this._getCollectionRef(record.type, record.id);
+    return this._getCollectionRef(record, record.id);
   },
 
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual) before sending PRs. We cannot accept code without this.

-->


### Description

Ember: 3.5.1
Ember Data: 3.5.2
Firebase: 3.9.0
EmberFire: 2.0.12

When trying to get the reference of a record via `this._getCollectionRef(record.type, record.id);`, `record.type` was returning `undefined` and that would lead to an incorrect reference to the root of the DB. 

`_getCollectionRef ` method calls internally `modelName` and that is an attribute of `record`, so now we are passing `record` instead of `record.type`.

Without this change, trying to save an embedded relationship would always put the related model in the root instead of inside the document.

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->