### PR TITLE
Enable Default Values

### DIFF
--- a/addon/serializers/firebase.js
+++ b/addon/serializers/firebase.js
@@ -46,9 +46,13 @@ export default DS.JSONSerializer.extend(DS.EmbeddedRecordsMixin, {
     var attributes = this._super(modelClass, resourceHash);
 
     // nullify omitted attributes
-    modelClass.eachAttribute((key) => {
+    modelClass.eachAttribute((key, meta) => {
       if (!attributes.hasOwnProperty(key)) {
-        attributes[key] = null;
+        if (meta && meta.options && meta.options.defaultValue != undefined) {
+          attributes[key] = meta.options.defaultValue;
+        } else {
+          attributes[key] = null;
+        }
       }
     });
 


### PR DESCRIPTION
This PR adds the ability to use the ```defaultValue``` property on the meta object passed to the ```attr()``` function. Before, each attribute that was not part of the JSON payload from Firebase was set to null by default.